### PR TITLE
Add support for packages

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -6,6 +6,11 @@ import (
 	"time"
 )
 
+const (
+	TemplateContentType = "text/html"
+	BundleContentType   = "application/json"
+)
+
 type Bundle struct {
 	ID
 	Rev         *string

--- a/files.go
+++ b/files.go
@@ -7,8 +7,6 @@ import (
 	"sync/atomic"
 )
 
-const HTMLTemplateContentType = "text/html+flashbacktmpl"
-
 type Attachment struct {
 	refcount    int32
 	ContentType string `json:"content-type"`

--- a/model.go
+++ b/model.go
@@ -2,7 +2,6 @@ package fb
 
 import (
 	"strconv"
-	// 	"encoding/json"
 )
 
 type Model struct {
@@ -39,7 +38,10 @@ func (m *Model) AddFile(name, ctype string, content []byte) error {
 }
 
 func (m *Model) Identity() string {
-	return m.Theme.ID.Identity() + "." + strconv.FormatUint(uint64(m.ID), 16)
+	if m.Theme != nil {
+		return m.Theme.ID.Identity() + "." + strconv.FormatUint(uint64(m.ID), 16)
+	}
+	return ""
 }
 
 func (m *Model) AddField(fType FieldType, name string) error {

--- a/package.go
+++ b/package.go
@@ -1,0 +1,10 @@
+package fb
+
+type Package struct {
+	Bundle  *Bundle   `json:"bundle,omitempty"`
+	Cards   []*Card   `json:"cards,omitempty"`
+	Notes   []*Note   `json:"notes,omitempty"`
+	Decks   []*Deck   `json:"decks,omitempty"`
+	Themes  []*Theme  `json:"themes,omitempty"`
+	Reviews []*Review `json:"reviews,omitempty"`
+}

--- a/test/card_test.go
+++ b/test/card_test.go
@@ -31,6 +31,6 @@ func TestCard(t *testing.T) {
 
 	if !reflect.DeepEqual(c, c2) {
 		PrintDiff(c2, c)
-		t.Fatal("Thawed and created Cards son't match")
+		t.Fatal("Thawed and created Cards don't match")
 	}
 }

--- a/test/note_test.go
+++ b/test/note_test.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"encoding/json"
+	"reflect"
 	"testing"
 
 	"github.com/flimzy/flashback-model"
@@ -32,7 +33,7 @@ var frozenNote []byte = []byte(`
 }
 `)
 
-func TestCreateNote(t *testing.T) {
+func TestNote(t *testing.T) {
 	th := &fb.Theme{}
 	json.Unmarshal(frozenTheme, th)
 	m := th.Models[1]
@@ -53,4 +54,18 @@ func TestCreateNote(t *testing.T) {
 		t.Fatal("Error attaching audio file")
 	}
 	JSONDeepEqual(t, "Create Note", Marshal(t, "Create Theme", n), frozenNote)
+
+	n2 := &fb.Note{}
+	if err := json.Unmarshal(frozenNote, n2); err != nil {
+		t.Fatalf("Error thawing note: %s", err)
+	}
+	// We have to set the model explicitly for the next test to pass
+	n2.SetModel(m)
+	JSONDeepEqual(t, "Thawed Note", Marshal(t, "Thaw Note", n2), frozenNote)
+
+	if !reflect.DeepEqual(n, n2) {
+		PrintDiff(n2, n)
+		t.Fatal("Thawed and created Notes don't match")
+	}
+
 }

--- a/test/package_test.go
+++ b/test/package_test.go
@@ -1,0 +1,191 @@
+package test
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/flimzy/flashback-model"
+	. "github.com/flimzy/flashback-model/test/util"
+)
+
+var frozenPackage []byte = []byte(`
+{
+    "bundle": {
+        "type": "bundle",
+        "_id": "bundle-VjMOV9J35iuH1lXdM_lgQPOYx9I=",
+        "owner": "nRHQJKEAQEWlt58cz5bMnw=="
+    },
+    "cards": [
+        {
+            "type": "card",
+            "_id": "card-mViuXQThMLoh1G1Nlc4d_E8kR8o=.0"
+        },
+        {
+            "type": "card",
+            "_id": "card-mViuXQThMLoh1G1Nlc4d_E8kR8o=.1"
+        },
+        {
+            "type": "card",
+            "_id": "card-mViuXQThMLoh1G1Nlc4d_E8kR8o=.2"
+        }
+    ],
+    "notes": [
+        {
+            "type": "note",
+            "_id": "note-VGVzdCBOb3RlCg==",
+            "model": "NVXGa7SD7zl4CpU_-R7o-qwAZs8=.1",
+            "fieldValues": [
+                {
+                    "text": "cat"
+                },
+                {
+                    "files": [
+                        "foo.mp3"
+                    ]
+                }
+            ],
+            "_attachments": {
+                "foo.mp3": {
+                    "content-type": "audio/mpeg",
+                    "data": "bm90IGEgcmVhbCBNUDM="
+                }
+            }
+        }
+    ],
+    "decks": [
+        {
+            "type": "deck",
+            "_id": "deck-AO1yee9FPLVtU3h0M5pcYy3AOTQ=",
+            "created": "2016-07-31T15:08:24.730156517Z",
+            "modified": "2016-07-31T15:08:24.730156517Z",
+            "name": "Test Deck",
+            "description": "Deck for testing",
+            "cards": []
+        }
+    ],
+    "themes": [
+        {
+            "type": "theme",
+            "_id": "theme-NVXGa7SD7zl4CpU_-R7o-qwAZs8=",
+            "created": "2016-07-31T15:08:24.730156517Z",
+            "modified": "2016-07-31T15:08:24.730156517Z",
+            "name": "Test Theme",
+            "description": "Theme for testing",
+            "models": [
+                {
+                    "id": 0,
+                    "modelType": 0,
+                    "name": "Model A",
+                    "templates": [],
+                    "fields": [
+                        {
+                            "fieldType": 0,
+                            "name": "Word"
+                        },
+                        {
+                            "fieldType": 0,
+                            "name": "Definition"
+                        }
+                    ],
+                    "files": [
+                        "m1.html"
+                    ]
+                },
+                {
+                    "id": 1,
+                    "modelType": 1,
+                    "name": "Model 2",
+                    "templates": [],
+                    "fields": [
+                        {
+                            "fieldType": 0,
+                            "name": "Word"
+                        },
+                        {
+                            "fieldType": 2,
+                            "name": "Audio"
+                        }
+                    ],
+                    "files": [
+                        "m1.txt"
+                    ]
+                }
+            ],
+            "_attachments": {
+                "$main.css": {
+                    "content-type": "text/css",
+                    "data": "LyogYW4gZW1wdHkgQ1NTIGZpbGUgKi8="
+                },
+                "m1.html": {
+                    "content-type": "text/html",
+                    "data": "PGh0bWw+PC9odG1sPg=="
+                },
+                "m1.txt": {
+                    "content-type": "text/plain",
+                    "data": "VGVzdCB0ZXh0IGZpbGU="
+                }
+            },
+            "files": [
+                "$main.css"
+            ],
+            "modelSequence": 2
+        }
+    ],
+    "reviews": [
+        {
+            "cardID": "mViuXQThMLoh1G1Nlc4d_E8kR8o=.0",
+            "timestamp": null,
+            "ease": 0,
+            "interval": null,
+            "previousInterval": null,
+            "srsFactor": 0,
+            "reviewTime": null,
+            "reviewType": 0
+        }
+    ]
+}
+`)
+
+func TestPackage(t *testing.T) {
+	u, _ := testUser()
+	b, _ := fb.NewBundle("VjMOV9J35iuH1lXdM_lgQPOYx9I=", u)
+	th := &fb.Theme{}
+	json.Unmarshal(frozenTheme, th)
+	d := &fb.Deck{}
+	json.Unmarshal(frozenDeck, d)
+	n := &fb.Note{}
+	fmt.Printf("model = %v\n", th.Models[1])
+	json.Unmarshal(frozenNote, n)
+	r := &fb.Review{}
+	json.Unmarshal(frozenReview, r)
+	p := &fb.Package{
+		Bundle:  b,
+		Cards:   make([]*fb.Card, 0),
+		Themes:  []*fb.Theme{th},
+		Decks:   []*fb.Deck{d},
+		Notes:   []*fb.Note{n},
+		Reviews: []*fb.Review{r},
+	}
+
+	for i := 0; i < 3; i++ {
+		c, _ := fb.NewCard("mViuXQThMLoh1G1Nlc4d_E8kR8o=", i)
+		p.Cards = append(p.Cards, c)
+	}
+	JSONDeepEqual(t, "Create Package", Marshal(t, "Create Package", p), frozenPackage)
+
+	p2 := &fb.Package{}
+	if err := json.Unmarshal(frozenPackage, p2); err != nil {
+		t.Fatalf("Error thawing package: %s", err)
+	}
+	JSONDeepEqual(t, "Thawed Package", Marshal(t, "Thaw Package", p2), frozenPackage)
+
+	// We have to set the username explicitly for the next test to pass, as a simple unmarshaling
+	// of a bundle doesn't know user details (nor should it)
+	p2.Bundle.Owner.Username = "mrsmith"
+	if !reflect.DeepEqual(p, p2) {
+		PrintDiff(p2, p)
+		t.Fatal("Thawed and created Packages don't match")
+	}
+}

--- a/user.go
+++ b/user.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"errors"
+
 	"github.com/pborman/uuid"
 )
 
@@ -106,4 +107,8 @@ func (u *User) UnmarshalJSON(data []byte) error {
 
 func (u *User) Fleshened() bool {
 	return u.Username != ""
+}
+
+func (u *User) Equal(id uuid.UUID) bool {
+	return uuid.Equal(u.uuid, id)
 }


### PR DESCRIPTION
A package struct can contain other document types and can be used for
exporting an entire JSON blob.

This also adds necessary tests for notes, which were missing, and JSON
unmarshaling for notes.