### PR TITLE
Make card ids in unit tests consistent

### DIFF
--- a/test/package_test.go
+++ b/test/package_test.go
@@ -22,19 +22,19 @@ var frozenPackage []byte = []byte(`
     "cards": [
         {
             "type": "card",
-            "_id": "card-mViuXQThMLoh1G1Nlc4d_E8kR8o.0",
+            "_id": "card-VGVzdCBOb3Rl.0",
             "created": "2016-07-31T15:08:24.730156517Z",
             "modified": "2016-07-31T15:08:24.730156517Z"
         },
         {
             "type": "card",
-            "_id": "card-mViuXQThMLoh1G1Nlc4d_E8kR8o.1",
+            "_id": "card-VGVzdCBOb3Rl.1",
             "created": "2016-07-31T15:08:24.730156517Z",
             "modified": "2016-07-31T15:08:24.730156517Z"
         },
         {
             "type": "card",
-            "_id": "card-mViuXQThMLoh1G1Nlc4d_E8kR8o.2",
+            "_id": "card-VGVzdCBOb3Rl.2",
             "created": "2016-07-31T15:08:24.730156517Z",
             "modified": "2016-07-31T15:08:24.730156517Z"
         }
@@ -148,7 +148,7 @@ var frozenPackage []byte = []byte(`
     ],
     "reviews": [
         {
-            "cardID": "mViuXQThMLoh1G1Nlc4d_E8kR8o.0",
+            "cardID": "VGVzdCBOb3Rl.0",
             "timestamp": null,
             "ease": 0,
             "interval": null,
@@ -187,7 +187,7 @@ func TestPackage(t *testing.T) {
 	}
 
 	for i := 0; i < 3; i++ {
-		c, _ := fb.NewCard(fmt.Sprintf("mViuXQThMLoh1G1Nlc4d_E8kR8o.%d", i))
+		c, _ := fb.NewCard(fmt.Sprintf("%s.%d", n.ID.Identity(), i))
 		c.Created = now
 		c.Modified = now
 		p.Cards = append(p.Cards, c)

--- a/test/review_test.go
+++ b/test/review_test.go
@@ -11,7 +11,7 @@ import (
 
 var frozenReview []byte = []byte(`
 {
-    "cardID": "mViuXQThMLoh1G1Nlc4d_E8kR8o.0",
+    "cardID": "VGVzdCBOb3Rl.0",
     "timestamp": null,
     "ease": 0,
     "interval": null,
@@ -23,7 +23,7 @@ var frozenReview []byte = []byte(`
 `)
 
 func TestReview(t *testing.T) {
-	r, err := fb.NewReview("mViuXQThMLoh1G1Nlc4d_E8kR8o.0")
+	r, err := fb.NewReview("VGVzdCBOb3Rl.0")
 	if err != nil {
 		t.Fatalf("Error creating review: %s\n", err)
 	}


### PR DESCRIPTION
That is, make them be derived from the note ids.