### PR TITLE
Completely segregate document ID and DB ID types

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -15,7 +15,7 @@ const (
 
 // Bundle represents a Bundle database.
 type Bundle struct {
-	ID          HexID
+	ID          DbID
 	Rev         *string
 	Created     time.Time
 	Modified    time.Time
@@ -27,7 +27,7 @@ type Bundle struct {
 
 type bundleDoc struct {
 	Type        string     `json:"type"`
-	ID          HexID      `json:"_id"`
+	ID          DbID       `json:"_id"`
 	Rev         *string    `json:"_rev,omitempty"`
 	Created     time.Time  `json:"created"`
 	Modified    time.Time  `json:"modified"`
@@ -40,7 +40,7 @@ type bundleDoc struct {
 // NewBundle creates a new Bundle with the provided id and owner.
 func NewBundle(id []byte, owner *User) (*Bundle, error) {
 	b := &Bundle{}
-	bid, err := NewHexID("bundle", id)
+	bid, err := NewDbID("bundle", id)
 	if err != nil {
 		return nil, err
 	}

--- a/dbid.go
+++ b/dbid.go
@@ -1,0 +1,100 @@
+package fb
+
+import (
+	"bytes"
+	"encoding/hex"
+	"errors"
+)
+
+var validDbIDTypes map[string]struct{}
+
+func init() {
+	validDbIDTypes = make(map[string]struct{})
+	for _, t := range []string{"bundle", "user"} {
+		validDbIDTypes[t] = struct{}{}
+	}
+}
+
+func isValidDbIDType(t string) bool {
+	_, ok := validDbIDTypes[t]
+	return ok
+}
+
+// DbID represents a standard document ID
+// Valid characters: a-z, 0-9, _, $, (, ), + -
+// See http://wiki.apache.org/couchdb/HTTP_database_API#Naming_and_Addressing
+type DbID struct {
+	docType string
+	id      []byte
+}
+
+// Type returns the DbID's docType.
+func (id *DbID) Type() string {
+	return id.docType
+}
+
+// ParseDbID parses a string representation of a DbID, returning the DbID.
+func ParseDbID(parts ...string) (DbID, error) {
+	docType, identity := parseParts(parts...)
+	data, err := hex.DecodeString(identity)
+	if err != nil {
+		return DbID{}, err
+	}
+	return NewDbID(docType, data)
+}
+
+func (id *DbID) parse(parts ...string) error {
+	docType, identity := parseParts(parts...)
+	data, err := hex.DecodeString(identity)
+	if err != nil {
+		return err
+	}
+	if !isValidDbIDType(docType) {
+		return errors.New("Invalid docType: " + docType)
+	}
+	id.docType = docType
+	id.id = data
+	return nil
+}
+
+// NewDbID returns a new DbID based on the specified docType and id.
+func NewDbID(docType string, id []byte) (DbID, error) {
+	if !isValidDbIDType(docType) {
+		return DbID{}, errors.New("Invalid document type:" + docType)
+	}
+	return DbID{
+		docType: docType,
+		id:      id,
+	}, nil
+}
+
+// MarshalJSON implements the json.Marshaler interface for the DbID type.
+func (id DbID) MarshalJSON() ([]byte, error) {
+	return []byte("\"" + id.String() + "\""), nil
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface for the DbID type.
+func (id *DbID) UnmarshalJSON(data []byte) error {
+	raw := string(data)
+	return id.parse(raw[1 : len(raw)-1])
+}
+
+// String returns the DbID's full string representation.
+func (id *DbID) String() string {
+	return id.docType + "-" + id.Identity()
+}
+
+// Identity returns the DbID's identity as a string.
+func (id *DbID) Identity() string {
+	return hex.EncodeToString(id.id)
+}
+
+// Equal returns true if both DbIDs are equal.
+func (id *DbID) Equal(id2 *DbID) bool {
+	return id.docType == id2.docType && bytes.Equal(id.id, id2.id)
+}
+
+// RawID returns the byte representation of the internal identity.
+func (id *DbID) RawID() []byte {
+	return id.id
+}

--- a/deck.go
+++ b/deck.go
@@ -54,7 +54,7 @@ func (cc *CardCollection) All() []string {
 
 // Deck represents a Flashback Deck
 type Deck struct {
-	ID          ID
+	ID          DocID
 	Rev         *string
 	Created     time.Time
 	Modified    time.Time
@@ -66,7 +66,7 @@ type Deck struct {
 
 type deckDoc struct {
 	Type        string          `json:"type"`
-	ID          ID              `json:"_id"`
+	ID          DocID           `json:"_id"`
 	Rev         *string         `json:"_rev,omitempty"`
 	Created     time.Time       `json:"created"`
 	Modified    time.Time       `json:"modified"`
@@ -118,7 +118,7 @@ type DeckConfig struct {
 
 // NewDeck creates a new Deck with the provided id.
 func NewDeck(id []byte) (*Deck, error) {
-	did, err := NewID("deck", id)
+	did, err := NewDocID("deck", id)
 	if err != nil {
 		return nil, err
 	}

--- a/id.go
+++ b/id.go
@@ -2,46 +2,33 @@ package fb
 
 import (
 	"bytes"
-	"encoding/hex"
 	"errors"
 	"strings"
 )
 
-var validTypes map[string]struct{}
+var validDocIDTypes map[string]struct{}
 
 func init() {
-	validTypes = make(map[string]struct{})
-	for _, t := range []string{"theme", "model", "note", "deck", "bundle", "card", "user"} {
-		validTypes[t] = struct{}{}
+	validDocIDTypes = make(map[string]struct{})
+	for _, t := range []string{"theme", "model", "note", "deck", "card"} {
+		validDocIDTypes[t] = struct{}{}
 	}
 }
 
-func isValidType(t string) bool {
-	_, ok := validTypes[t]
+func isValidDocIDType(t string) bool {
+	_, ok := validDocIDTypes[t]
 	return ok
 }
 
-type baseID struct {
+// DocID represents a standard document ID
+// Current implementation uses Base64
+type DocID struct {
 	docType string
 	id      []byte
 }
 
-// ID represents a standard Base64-encoded ID
-type ID struct {
-	baseID
-}
-
-func newBaseID(docType string, id []byte) (baseID, error) {
-	if !isValidType(docType) {
-		return baseID{}, errors.New("Invalid document type:" + docType)
-	}
-	return baseID{
-		docType: docType,
-		id:      id,
-	}, nil
-}
-
-func (id *baseID) Type() string {
+// Type returns the DocID's docType.
+func (id *DocID) Type() string {
 	return id.docType
 }
 
@@ -57,123 +44,60 @@ func parseParts(input ...string) (string, string) {
 	}
 }
 
-// ParseID parses a string reprsentation of an ID, returning the ID or an error.
-func ParseID(parts ...string) (ID, error) {
-	id := ID{}
+// ParseDocID parses a string reprsentation of a DocID, returning the DocID or an error.
+func ParseDocID(parts ...string) (DocID, error) {
+	id := DocID{}
 	err := id.parse(parts...)
 	return id, err
 }
 
-func (id *ID) parse(parts ...string) error {
+func (id *DocID) parse(parts ...string) error {
 	docType, identity := parseParts(parts...)
 	data, err := b64encoder.DecodeString(identity)
 	if err != nil {
 		return err
 	}
-	base, err := newBaseID(docType, data)
-	if err != nil {
-		return err
+	if !isValidDocIDType(docType) {
+		return errors.New("Invalid docType: " + docType)
 	}
-	id.baseID = base
+	id.docType = docType
+	id.id = data
 	return nil
 }
 
-// NewID returns a new ID with the provided docType and Identity.
-func NewID(docType string, id []byte) (ID, error) {
-	base, err := newBaseID(docType, id)
-	return ID{base}, err
+// NewDocID returns a new ID with the provided docType and Identity.
+func NewDocID(docType string, id []byte) (DocID, error) {
+	if !isValidDocIDType(docType) {
+		return DocID{}, errors.New("Invalid document type:" + docType)
+	}
+	return DocID{
+		docType: docType,
+		id:      id,
+	}, nil
 }
 
-// MarshalJSON implements the json.Marshaler interface for the ID type.
-func (id ID) MarshalJSON() ([]byte, error) {
+// MarshalJSON implements the json.Marshaler interface for the DocID type.
+func (id DocID) MarshalJSON() ([]byte, error) {
 	return []byte("\"" + id.String() + "\""), nil
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface for the ID type.
-func (id *ID) UnmarshalJSON(data []byte) error {
+func (id *DocID) UnmarshalJSON(data []byte) error {
 	raw := string(data)
 	return id.parse(raw[1 : len(raw)-1])
 }
 
 // String returns the full string representation of the ID.
-func (id *ID) String() string {
+func (id *DocID) String() string {
 	return id.docType + "-" + id.Identity()
 }
 
-// Identity returns a string representation of the internal ID only.
-func (id *ID) Identity() string {
+// Identity returns a string representation of the internal identity only.
+func (id *DocID) Identity() string {
 	return b64encoder.EncodeToString(id.id)
 }
 
-// Equal returns true if the two IDs are considered equal.
-func (id *ID) Equal(id2 *ID) bool {
+// Equal returns true if the two DocIDs are considered equal.
+func (id *DocID) Equal(id2 *DocID) bool {
 	return id.docType == id2.docType && bytes.Equal(id.id, id2.id)
-}
-
-// HexID represents a Hex-encoded ID, for documents which need their own databases
-// (which don't support Base64 alphabets)
-type HexID struct {
-	baseID
-}
-
-// ParseHexID parses a string representation of a HexID, returning the HexID.
-func ParseHexID(parts ...string) (HexID, error) {
-	docType, identity := parseParts(parts...)
-	data, err := hex.DecodeString(identity)
-	if err != nil {
-		return HexID{}, err
-	}
-	id, err := newBaseID(docType, data)
-	return HexID{id}, err
-}
-
-func (id *HexID) parse(parts ...string) error {
-	docType, identity := parseParts(parts...)
-	data, err := hex.DecodeString(identity)
-	if err != nil {
-		return err
-	}
-	base, err := newBaseID(docType, data)
-	if err != nil {
-		return err
-	}
-	id.baseID = base
-	return nil
-}
-
-// NewHexID returns a new HexID based on the specified docType and id.
-func NewHexID(docType string, id []byte) (HexID, error) {
-	base, err := newBaseID(docType, id)
-	return HexID{base}, err
-}
-
-// MarshalJSON implements the json.Marshaler interface for the HexID type.
-func (id HexID) MarshalJSON() ([]byte, error) {
-	return []byte("\"" + id.String() + "\""), nil
-}
-
-// UnmarshalJSON implements the json.Unmarshaler interface for the HexID type.
-func (id *HexID) UnmarshalJSON(data []byte) error {
-	raw := string(data)
-	return id.parse(raw[1 : len(raw)-1])
-}
-
-// String returns the HexID's full string representation.
-func (id *HexID) String() string {
-	return id.docType + "-" + id.Identity()
-}
-
-// Identity returns the HexID's identity as a string.
-func (id *HexID) Identity() string {
-	return hex.EncodeToString(id.id)
-}
-
-// Equal returns true if both HexIDs are equal.
-func (id *HexID) Equal(id2 *HexID) bool {
-	return id.docType == id2.docType && bytes.Equal(id.id, id2.id)
-}
-
-// RawID returns the byte representation of the internal identity.
-func (id *HexID) RawID() []byte {
-	return id.id
 }

--- a/id_test.go
+++ b/id_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestID(t *testing.T) {
-	id, err := NewID("note", []byte("Test Note"))
+	id, err := NewDocID("note", []byte("Test Note"))
 	if err != nil {
 		t.Fatalf("Error creating note ID: %s", err)
 	}
@@ -18,8 +18,8 @@ func TestID(t *testing.T) {
 	}
 }
 
-func TestHexID(t *testing.T) {
-	id, err := NewHexID("user", []byte("Test User"))
+func TestDbID(t *testing.T) {
+	id, err := NewDbID("user", []byte("Test User"))
 	if err != nil {
 		t.Fatalf("Error creating user ID: %s", err)
 	}

--- a/note.go
+++ b/note.go
@@ -8,7 +8,7 @@ import (
 
 // Note represents a Flashback note.
 type Note struct {
-	ID          ID
+	ID          DocID
 	Rev         *string
 	Created     time.Time
 	Modified    time.Time
@@ -29,7 +29,7 @@ type Note struct {
 
 type noteDoc struct {
 	Type        string          `json:"type"`
-	ID          ID              `json:"_id"`
+	ID          DocID           `json:"_id"`
 	Rev         *string         `json:"_rev,omitempty"`
 	Created     time.Time       `json:"created"`
 	Modified    time.Time       `json:"modified"`
@@ -42,7 +42,7 @@ type noteDoc struct {
 // NewNote creates a new, empty note with the provided ID and Model.
 func NewNote(id []byte, model *Model) (*Note, error) {
 	n := &Note{}
-	nid, err := NewID("note", id)
+	nid, err := NewDocID("note", id)
 	if err != nil {
 		return nil, err
 	}

--- a/test/bundle_test.go
+++ b/test/bundle_test.go
@@ -12,11 +12,11 @@ import (
 var frozenBundle = []byte(`
 {
     "type": "bundle",
-    "_id": "bundle-546573742042756e646c65",
+    "_id": "bundle-krsxg5baij2w4zdmmu",
     "created": "2016-07-31T15:08:24.730156517Z",
     "modified": "2016-07-31T15:08:24.730156517Z",
     "imported": "2016-08-02T15:08:24.730156517Z",
-    "owner": "9d11d024a1004045a5b79f1ccf96cc9f",
+    "owner": "tui5ajfbabaeljnxt4om7fwmt4",
     "name": "Test Bundle",
     "description": "A bundle for testing"
 }
@@ -36,7 +36,7 @@ func TestNewBundle(t *testing.T) {
 	b.Imported = &imp
 	descr := "A bundle for testing"
 	b.Description = &descr
-	StringsEqual(t, "Bundle ID", b.ID.String(), "bundle-546573742042756e646c65")
+	StringsEqual(t, "Bundle ID", b.ID.String(), "bundle-krsxg5baij2w4zdmmu")
 	JSONDeepEqual(t, "New Bundle", Marshal(t, "New bundle", b), frozenBundle)
 
 	b2 := &fb.Bundle{}

--- a/test/id_test.go
+++ b/test/id_test.go
@@ -9,11 +9,11 @@ import (
 	. "github.com/flimzy/flashback-model/test/util"
 )
 
-var frozenB64ID = []byte(`"note-VGVzdCBOb3Rl"`)
+var frozenDocID = []byte(`"note-VGVzdCBOb3Rl"`)
 var frozenHexID = []byte(`"user-546573742055736572"`)
 
-func TestB64ID(t *testing.T) {
-	id, err := fb.NewID("note", []byte("Test Note"))
+func TestDocID(t *testing.T) {
+	id, err := fb.NewDocID("note", []byte("Test Note"))
 	if err != nil {
 		t.Fatalf("Error creating B64 ID: %s\n", err)
 	}
@@ -23,13 +23,13 @@ func TestB64ID(t *testing.T) {
 	if id.Identity() != "VGVzdCBOb3Rl" {
 		t.Fatalf("Unexpected identity for note id. Got %s\n", id.Identity())
 	}
-	JSONDeepEqual(t, "Create B64 ID", Marshal(t, "Create ID1", id), frozenB64ID)
+	JSONDeepEqual(t, "Create DocID", Marshal(t, "Create ID1", id), frozenDocID)
 
-	id2 := fb.ID{}
-	if err := json.Unmarshal(frozenB64ID, &id2); err != nil {
-		t.Fatalf("Error thawing B64 ID: %s", err)
+	id2 := fb.DocID{}
+	if err := json.Unmarshal(frozenDocID, &id2); err != nil {
+		t.Fatalf("Error thawing DocID: %s", err)
 	}
-	JSONDeepEqual(t, "Thawed B64 ID", Marshal(t, "Thaw B64 ID", id2), frozenB64ID)
+	JSONDeepEqual(t, "Thawed DocID", Marshal(t, "Thaw DocID", id2), frozenDocID)
 
 	if !reflect.DeepEqual(id, id2) {
 		PrintDiff(id2, id)
@@ -37,8 +37,8 @@ func TestB64ID(t *testing.T) {
 	}
 }
 
-func TestHexID(t *testing.T) {
-	id, err := fb.NewHexID("user", []byte("Test User"))
+func TestDbID(t *testing.T) {
+	id, err := fb.NewDbID("user", []byte("Test User"))
 	if err != nil {
 		t.Fatalf("Error creating Hex ID: %s\n", err)
 	}
@@ -50,7 +50,7 @@ func TestHexID(t *testing.T) {
 	}
 	JSONDeepEqual(t, "Create Hex ID", Marshal(t, "Create ID1", id), frozenHexID)
 
-	id2 := fb.HexID{}
+	id2 := fb.DbID{}
 	if err := json.Unmarshal(frozenHexID, &id2); err != nil {
 		t.Fatalf("Error thawing Hex ID: %s", err)
 	}
@@ -63,11 +63,11 @@ func TestHexID(t *testing.T) {
 }
 
 func TestID(t *testing.T) {
-	id, err := fb.NewID("user", []byte("User Bob"))
+	id, err := fb.NewDbID("user", []byte("User Bob"))
 	if err != nil {
 		t.Fatalf("Error creating user: %s\n", err)
 	}
-	id2, err := fb.ParseID(id.String())
+	id2, err := fb.ParseDbID(id.String())
 	if err != nil {
 		t.Fatalf("We can't even parse the IDs we generate: %s", err.Error())
 	}
@@ -80,11 +80,11 @@ func TestID(t *testing.T) {
 }
 
 func TestID2(t *testing.T) {
-	id, err := fb.NewID("user", []byte("User Bob"))
+	id, err := fb.NewDbID("user", []byte("User Bob"))
 	if err != nil {
 		t.Fatalf("Error creating user: %s\n", err)
 	}
-	id2, err := fb.ParseID(id.String())
+	id2, err := fb.ParseDbID(id.String())
 	if err != nil {
 		t.Fatalf("We can't even parse the IDs we generate: %s", err.Error())
 	}

--- a/test/id_test.go
+++ b/test/id_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 var frozenDocID = []byte(`"note-VGVzdCBOb3Rl"`)
-var frozenHexID = []byte(`"user-546573742055736572"`)
+var frozenDbID = []byte(`"user-krsxg5bakvzwk4q"`)
 
 func TestDocID(t *testing.T) {
 	id, err := fb.NewDocID("note", []byte("Test Note"))
@@ -42,19 +42,19 @@ func TestDbID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating Hex ID: %s\n", err)
 	}
-	if id.String() != "user-546573742055736572" {
+	if id.String() != "user-krsxg5bakvzwk4q" {
 		t.Fatalf("Error stringifying note id. Got %s\n", id.String())
 	}
-	if id.Identity() != "546573742055736572" {
+	if id.Identity() != "krsxg5bakvzwk4q" {
 		t.Fatalf("Unexpected identity for note id. Got %s\n", id.Identity())
 	}
-	JSONDeepEqual(t, "Create Hex ID", Marshal(t, "Create ID1", id), frozenHexID)
+	JSONDeepEqual(t, "Create Hex ID", Marshal(t, "Create ID1", id), frozenDbID)
 
 	id2 := fb.DbID{}
-	if err := json.Unmarshal(frozenHexID, &id2); err != nil {
+	if err := json.Unmarshal(frozenDbID, &id2); err != nil {
 		t.Fatalf("Error thawing Hex ID: %s", err)
 	}
-	JSONDeepEqual(t, "Thawed Hex ID", Marshal(t, "Thaw Hex ID", id2), frozenHexID)
+	JSONDeepEqual(t, "Thawed Hex ID", Marshal(t, "Thaw Hex ID", id2), frozenDbID)
 
 	if !reflect.DeepEqual(id, id2) {
 		PrintDiff(id2, id)

--- a/test/package_test.go
+++ b/test/package_test.go
@@ -14,10 +14,10 @@ var frozenPackage = []byte(`
 {
     "bundle": {
         "type": "bundle",
-        "_id": "bundle-546573742042756e646c65",
+        "_id": "bundle-krsxg5baij2w4zdmmu",
         "created": "2016-07-31T15:08:24.730156517Z",
         "modified": "2016-07-31T15:08:24.730156517Z",
-        "owner": "9d11d024a1004045a5b79f1ccf96cc9f"
+        "owner": "tui5ajfbabaeljnxt4om7fwmt4"
     },
     "cards": [
         {

--- a/test/user_test.go
+++ b/test/user_test.go
@@ -14,7 +14,7 @@ import (
 var frozenUser = []byte(`
 {
     "type": "user",
-    "_id": "user-9d11d024a1004045a5b79f1ccf96cc9f",
+    "_id": "user-tui5ajfbabaeljnxt4om7fwmt4",
     "username": "mrsmith",
     "password": "",
     "salt": "",
@@ -27,7 +27,7 @@ func TestNewUser(t *testing.T) {
 	if err != nil {
 		t.Errorf("Error creating user: %s\n", err)
 	}
-	StringsEqual(t, "ID", u.ID.String(), "user-9d11d024a1004045a5b79f1ccf96cc9f")
+	StringsEqual(t, "ID", u.ID.String(), "user-tui5ajfbabaeljnxt4om7fwmt4")
 	StringsEqual(t, "Type", u.ID.Type(), "user")
 	JSONDeepEqual(t, "New user", Marshal(t, "New User", u), frozenUser)
 

--- a/theme.go
+++ b/theme.go
@@ -9,7 +9,7 @@ import (
 
 // Theme represents a flackback Theme definition
 type Theme struct {
-	ID            ID
+	ID            DocID
 	Rev           *string
 	Created       time.Time
 	Modified      time.Time
@@ -24,7 +24,7 @@ type Theme struct {
 
 type themeDoc struct {
 	Type          string              `json:"type"`
-	ID            ID                  `json:"_id"`
+	ID            DocID               `json:"_id"`
 	Rev           *string             `json:"_rev,omitempty"`
 	Created       time.Time           `json:"created"`
 	Modified      time.Time           `json:"modified"`
@@ -40,7 +40,7 @@ type themeDoc struct {
 // NewTheme returns a new, bare-bones theme, with the specified ID.
 func NewTheme(id []byte) (*Theme, error) {
 	t := &Theme{}
-	tid, err := NewID("theme", id)
+	tid, err := NewDocID("theme", id)
 	if err != nil {
 		return nil, err
 	}

--- a/user.go
+++ b/user.go
@@ -13,7 +13,7 @@ func isValidID(id string) bool {
 
 // User repressents a user of Flashback
 type User struct {
-	ID       HexID
+	ID       DbID
 	uuid     uuid.UUID
 	Rev      *string
 	Username string
@@ -26,7 +26,7 @@ type User struct {
 
 type userDoc struct {
 	Type     string  `json:"type"`
-	ID       HexID   `json:"_id"`
+	ID       DbID    `json:"_id"`
 	Rev      *string `json:"_rev,omitempty"`
 	Username string  `json:"username"`
 	Password string  `json:"password"`
@@ -44,7 +44,7 @@ type userDoc struct {
 
 // NewUser returns a new User object, based on the provided UUID and username.
 func NewUser(id uuid.UUID, username string) (*User, error) {
-	uid, err := NewHexID("user", id)
+	uid, err := NewDbID("user", id)
 	if err != nil {
 		return nil, err
 	}
@@ -57,7 +57,7 @@ func NewUser(id uuid.UUID, username string) (*User, error) {
 
 // NewUserStub returns a new stub (bare bones) User object.
 func NewUserStub(id string) (*User, error) {
-	userID, err := ParseHexID("user", id)
+	userID, err := ParseDbID("user", id)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
- Rename ID to DocID, and HexID to DbID, to follow usage, rather than implementation
- Completely segregate the two data types (no more shared baseID type underlying)
- This will make it easier to change implementations (i.e. base32 instead of hex, base91 instead of base64, etc)
- This will also make it easier to expand the DocID to include the BundleID.